### PR TITLE
Kahan summation for time stepping

### DIFF
--- a/src/+matlode/+stepsizecontroller/Gustafson.m
+++ b/src/+matlode/+stepsizecontroller/Gustafson.m
@@ -32,13 +32,12 @@ classdef Gustafson < matlode.stepsizecontroller.StepSizeController
             
         end
         
-        function [accept, hNew, tNew] = newStepSize(obj, prevAccept, t, ~, h, err, q)
+        function [accept, hNew] = newStepSize(obj, prevAccept, ~, h, err, q)
             accept = err(1) <= 1;
             
             scalh = 1;
             
             if accept
-                tNew = t + h(1);
                 if ~prevAccept
                     %H_0220 Controller
                    scalh = (h(1) / h(2))^obj.A; 
@@ -46,7 +45,6 @@ classdef Gustafson < matlode.stepsizecontroller.StepSizeController
                 %PI Controller
                 scalerr = err(1)^(obj.Ki/q) * err(2)^(obj.Kp/q);
             else
-                tNew = t;
                 %Standard Controller(I controller)
                 scalerr = err(1)^(-1/(q + 1));
             end

--- a/src/+matlode/+stepsizecontroller/SoderlandController.m
+++ b/src/+matlode/+stepsizecontroller/SoderlandController.m
@@ -46,16 +46,9 @@ classdef SoderlandController < matlode.stepsizecontroller.StepSizeController
             obj.AQfunc = opts.AQfunc;
         end
         
-        function [accept, hNew, tNew] = newStepSize(obj, ~, t, ~, h, err, q)
+        function [accept, hNew] = newStepSize(obj, ~, ~, h, err, q)
             
             accept = err(1) <= 1; 
-            if accept
-                tNew = t + h(1);
-                
-            else
-                tNew = t;
-            end
-            
             
             facScal = prod(err(1:obj.History).^obj.AQfunc(q,obj.A));
             hScal = prod(abs(h(1:obj.History - 1) ./ h(2:obj.History)).^obj.B);

--- a/src/+matlode/+stepsizecontroller/StandardController.m
+++ b/src/+matlode/+stepsizecontroller/StandardController.m
@@ -10,14 +10,8 @@ classdef StandardController < matlode.stepsizecontroller.StepSizeController
             
         end
         
-        function [accept, hNew, tNew] = newStepSize(obj, ~, t, ~, h, err, q)
+        function [accept, hNew] = newStepSize(obj, ~, ~, h, err, q)
             accept = err <= 1;
-            
-            if accept
-                tNew = t + h;
-            else
-                tNew = t;
-            end
             
             hNew = h * min(obj.FacMax, max(obj.FacMin, obj.Fac * err^(-1 / (q + 1))));
             

--- a/src/+matlode/+stepsizecontroller/StepSizeController.m
+++ b/src/+matlode/+stepsizecontroller/StepSizeController.m
@@ -35,7 +35,7 @@ classdef (Abstract) StepSizeController < handle
     end
     
     methods (Abstract)
-        [accept, hNew, tNew] = newStepSize(obj, prevAccept, t, tspan, h, err, q);
+        [accept, hNew] = newStepSize(obj, prevAccept, tspan, h, err, q);
 	end
     
     methods

--- a/src/+matlode/Integrator.m
+++ b/src/+matlode/Integrator.m
@@ -107,7 +107,8 @@ classdef (Abstract) Integrator < handle
 			p.addParameter('FullTrajectory', false);
             p.addParameter('Dense', []);
             p.addParameter('MaxStep', inf);
-			
+            p.addParameter('MinStep', 0, @(x) isscalar(x) && isfloat(x) && x >= 0)
+			p.addParameter('MaxNumSteps', inf, @(x) isscalar(x) && isnumeric(x) && floor(x) == x)
             
             p.parse(varargin{:});
             

--- a/src/+matlode/OneStepIntegrator.m
+++ b/src/+matlode/OneStepIntegrator.m
@@ -46,13 +46,14 @@ classdef (Abstract) OneStepIntegrator < matlode.Integrator
             %inital values
             tcur = tspan(1);
             tnext = tcur;
+            dtbuf = 0; % Kahan summation buffer to remember small parts of dt which haven't yet been added to t
             tindex = 2;
             
             tspanlen = length(tspan);
             
             tdir = sign(tspan(end) - tspan(1));
             dtmax = min([abs(opts.MaxStep), abs(tspan(end) - tspan(1))]) * tdir;
-            dtmin = 64 * eps(tspan(1)) * tdir;
+            dtmin = opts.MinStep * tdir;
             
             ynext = y0;
             
@@ -76,6 +77,11 @@ classdef (Abstract) OneStepIntegrator < matlode.Integrator
             
             %Time Loop
             while tindex <= tspanlen
+                if(stats.nSteps > opts.MaxNumSteps)
+                    warning("OneStepIntegrator:MaxNumSteps", "Integrator reached maximum steps before finishing integration at t = %f.", tcur)
+                    break
+                end
+
                 %Cycle history
                 err = circshift(err, 1, 2);
                 dthist = circshift(dthist, 1, 2);
@@ -84,9 +90,6 @@ classdef (Abstract) OneStepIntegrator < matlode.Integrator
                 tcur = tnext;
                 dtcur = dtnext;
                 dthist(1) = dtnext;
-                
-                %Subject to change
-                dtmin = 64 * eps(tcur) * tdir;
                 
                 %Accept Loop
                 %Will keep looping until accepted step
@@ -99,33 +102,36 @@ classdef (Abstract) OneStepIntegrator < matlode.Integrator
                     	
                     	%Find next Step
 						%TODO: Update to take stats
-                    	[prevAccept, dtnext, tnext] = stepController.newStepSize(prevAccept, tcur, tspan, dthist, err, q);
+                    	[prevAccept, dtnext] = stepController.newStepSize(prevAccept, tspan, dthist, err, q);
 					else
 						%TODO setup with memory based time step controller
 						prevAccept = false;
 						%TODO: Allow factor to be choosen
 						dtnext = 0.1 * dtcur;
-						tnext = tcur;
 					end
 
-                	%Check if step is really small
+                	% Verify we don't go below MinStep.
                 	if abs(dtnext) < abs(dtmin)
-						%Prevents excessive output
-                    	if stats.nSmallSteps == 0
-                        	warning('The step the integrator is taking extremely small, results may not be optimal')
-                    	end
-                    	%accept step since the step cannot get any smaller
-                    	stats.nSmallSteps = stats.nSmallSteps + 1;
                     	dtnext = dtmin;
-                    	tnext = tcur + dtmin;
-                    	prevAccept = true;
-                    	break;
                 	end
                 	
                 	%check step acception
-                	if prevAccept
-                    	break;
-                	end
+                    if prevAccept
+                        % Kahan summation - adjust dt by adding the parts of previous dt
+                        % that we haven't been able to add yet
+                        dtadj = dtcur + dtbuf;
+                        tnext = tcur + dtadj;
+
+                        % Due to rounding error, tnext - tcur may not properly capture all of dtadj,
+                        % so record the parts that are missing to be added later
+                        dtbuf = dtadj - (tnext - tcur);
+                        break;
+                    else
+                        if dtcur == dtmin
+                            % TODO maybe we should return our progress up until now
+                            error("OneStepIntegrator:MinStep", "Step failed with h = MinStep")
+                        end
+                    end
                 	
                 	stats.nFailed = stats.nFailed + 1;
                 	dtcur = dtnext;
@@ -156,7 +162,7 @@ classdef (Abstract) OneStepIntegrator < matlode.Integrator
                         
                         %incase lucky and land on point, can be cheaper
                         %than dense output if dense requires fevals
-                        if abs(tspan(tindex) - tnext) < abs(dtmin)
+                        if abs(tspan(tindex) - tnext) < 64 * eps(tcur)
                             t(:, tindex) = tspan(tindex);
                             y(:, tindex) = ynext;
                         else
@@ -175,7 +181,7 @@ classdef (Abstract) OneStepIntegrator < matlode.Integrator
                     
                     %integrate to/ End point
                     %check if close enough with hmin
-                    if abs(tspan(tindex) - tnext) < abs(dtmin)
+                    if abs(tspan(tindex) - tnext) < 64 * eps(tnext)
 
                         if multiTspan
                             t(:, tindex) = tspan(tindex);
@@ -184,6 +190,7 @@ classdef (Abstract) OneStepIntegrator < matlode.Integrator
                         tindex = tindex + 1;
 					else
                         
+                        % TODO - what if this is < dtmin
                         dtnext = tspan(tindex) - tnext;
                     end
                     


### PR DESCRIPTION
- Added new MinStep parameter, which defaults to 0. If time steps fail while at this step, then an error is produced.
- Added new MaxNumSteps parameter, which defaults to infinity. If we attempt to step while having already taken the maximum numer of steps, then the current solution is returned and a warning is produced. Use this to allow the integrator to take small steps but not spend too long there.
- The current simulation time is kept track of using Kahan summation, so small values of dt will not produce inaccuracies.

To facilitate Kahan summation for simulation time, the sum to produce the next step time was removed from the step size controller.